### PR TITLE
Fix oled display i2c errors

### DIFF
--- a/oled-display/CHANGELOG.md
+++ b/oled-display/CHANGELOG.md
@@ -18,5 +18,8 @@ All notable changes to the "OLED System Monitor" Home Assistant add-on are docum
 - Slim Docker image dependencies for HA OS base
 - Update README for HA OS on RPi 5 only
 
+### Internal
+- Migrate base image to `ghcr.io/home-assistant/aarch64-addon-base:3.18`
+
 ## 1.0.0
 - Initial public release

--- a/oled-display/CHANGELOG.md
+++ b/oled-display/CHANGELOG.md
@@ -11,5 +11,12 @@ All notable changes to the "OLED System Monitor" Home Assistant add-on are docum
 - Change default system title to "home assistant"
 - Update README default value table
 
+## 1.2.0 - 2025-09-15
+- Limit add-on to Raspberry Pi 5 (aarch64) on Home Assistant OS
+- Flatten configuration to single-page options with labels/descriptions
+- Add automatic debug-mode fallback when I2C/OLED init fails
+- Slim Docker image dependencies for HA OS base
+- Update README for HA OS on RPi 5 only
+
 ## 1.0.0
 - Initial public release

--- a/oled-display/Dockerfile
+++ b/oled-display/Dockerfile
@@ -1,21 +1,15 @@
 ARG BUILD_FROM
 FROM ${BUILD_FROM}
 
-# Install required dependencies including development headers
+# Install required runtime dependencies only
 RUN apk add --no-cache \
     python3 \
     py3-pip \
     py3-pillow \
     py3-psutil \
-    i2c-tools \
-    linux-headers \
-    zlib-dev \
-    jpeg-dev \
-    gcc \
-    python3-dev \
-    musl-dev
+    i2c-tools
 
-# Install Python packages with pre-built wheels
+# Install Python packages
 RUN pip3 install --no-cache-dir \
     luma.oled \
     luma.core
@@ -30,4 +24,4 @@ RUN chmod a+x /etc/services.d/oled/run
 LABEL \
   io.hass.name="OLED System Monitor" \
   io.hass.description="Displays system stats on an OLED display" \
-  io.hass.arch="armhf|aarch64|i386|amd64"
+  io.hass.arch="aarch64"

--- a/oled-display/README.md
+++ b/oled-display/README.md
@@ -1,6 +1,6 @@
 # OLED System Monitor Add-on (Home Assistant OS on Raspberry Pi 5)
 
-This add-on displays system information on an OLED display connected to a Raspberry Pi 5 running Home Assistant OS, using the I2C interface.
+This add-on displays system information on an OLED display connected to a Raspberry Pi 5 running Home Assistant OS, using the I2C interface. It targets RPi 5 (aarch64) exclusively.
 
 ## Features
 
@@ -13,7 +13,7 @@ This add-on displays system information on an OLED display connected to a Raspbe
 - Automatic I2C device detection
 - Debug mode for testing without OLED display
 
-## Installation (Home Assistant OS, Raspberry Pi 5)
+## Installation (Home Assistant OS, Raspberry Pi 5 only)
 
 1. Add the custom repository to Home Assistant:
    - Settings → Add-ons → Add-on Store → ⋮ → Repositories → Add the repo URL → Add
@@ -21,7 +21,7 @@ This add-on displays system information on an OLED display connected to a Raspbe
 3. Enable I2C on the host:
    - Settings → System → Hardware → All hardware → ⋮ menu → Enable I2C → Reboot host.
    - After reboot, verify I2C is present: Settings → System → Hardware → look for `/dev/i2c-1`.
-4. Start the add-on.
+4. Start the add-on. If I2C is not yet present, the add-on will log metrics in debug mode until `/dev/i2c-1` is exposed by HA OS.
 
 ## Hardware Setup (RPi 5)
 

--- a/oled-display/README.md
+++ b/oled-display/README.md
@@ -1,6 +1,6 @@
-# OLED System Monitor Add-on for Home Assistant
+# OLED System Monitor Add-on (Home Assistant OS on Raspberry Pi 5)
 
-This add-on displays system information on an OLED display connected to your Home Assistant device via I2C.
+This add-on displays system information on an OLED display connected to a Raspberry Pi 5 running Home Assistant OS, using the I2C interface.
 
 ## Features
 
@@ -13,140 +13,88 @@ This add-on displays system information on an OLED display connected to your Hom
 - Automatic I2C device detection
 - Debug mode for testing without OLED display
 
-## Installation
+## Installation (Home Assistant OS, Raspberry Pi 5)
 
-1. Add this repository to your Home Assistant instance
-2. Install the "OLED System Monitor" add-on
-3. Configure the add-on with your display settings
-4. Start the add-on
+1. Add the custom repository to Home Assistant:
+   - Settings → Add-ons → Add-on Store → ⋮ → Repositories → Add the repo URL → Add
+2. Install the "OLED System Monitor" add-on from the store.
+3. Enable I2C on the host:
+   - Settings → System → Hardware → All hardware → ⋮ menu → Enable I2C → Reboot host.
+   - After reboot, verify I2C is present: Settings → System → Hardware → look for `/dev/i2c-1`.
+4. Start the add-on.
 
-## Hardware Setup
+## Hardware Setup (RPi 5)
 
-Connect your OLED display to the Raspberry Pi:
+Connect your OLED display to the Raspberry Pi 5 header:
 - VCC → 3.3V
 - GND → Ground
 - SCL → GPIO 3 (SCL)
 - SDA → GPIO 2 (SDA)
 
-Make sure I2C is enabled on your Home Assistant device.
+Ensure I2C is enabled in Home Assistant OS (see Installation step 3).
 
-## Configuration
+## Configuration (single-page)
 
-### Display Options
+The add-on presents simple, descriptive settings. Legacy nested options remain supported for compatibility.
 
-| Option | Description | Default |
-|--------|-------------|---------|
-| `type` | Display type (ssd1306 or sh1106) | sh1106 |
-| `i2c_address` | I2C address of the display (usually 0x3C) | 0x3C |
-| `i2c_port` | I2C port (auto, 0, 1, etc.) | auto |
-| `width` | Display width in pixels | 128 |
-| `height` | Display height in pixels | 64 |
-| `rotate` | Display rotation (0, 1, 2, 3) | 0 |
-| `contrast` | Display contrast (0-255) | 255 |
+Key settings:
 
-### System Options
+- `display_type` (ssd1306|sh1106): Your OLED controller type. Most 128x64 modules are sh1106 or ssd1306.
+- `i2c_address`: Hex address of your display. Commonly `0x3C`.
+- `i2c_port`: I2C bus number. Use `auto` for RPi 5 (usually `1`).
+- `width`, `height`: Pixel dimensions. Common modules are 128x64.
+- `rotate`: 0,1,2,3 to rotate display if oriented differently.
+- `contrast`: 0–255 brightness level.
+- `update_interval`: Seconds between screen updates.
+- `title`, `show_title`, `show_temperature`: Header line controls.
+- `show_cpu`, `show_memory`, `show_disk`, `show_temperature_metric`, `show_uptime`: Toggle metrics. `disk_mount_point` for disk metric path.
+- `custom_text_enabled`, `custom_text`, `custom_text_position`: Optional custom line.
+- `show_ip`, `network_interface`, `network_label`, `network_position`: IP address line.
 
-| Option | Description | Default |
-|--------|-------------|---------|
-| `update_interval` | Update interval in seconds | 1 |
-| `title` | Title to display | home assistant |
-| `show_title` | Whether to show the title | true |
-| `show_temperature` | Whether to show temperature with title | true |
-| `debug_mode` | Run in debug mode (console output only) | false |
+## Troubleshooting (HA OS on RPi 5)
 
-### Metrics
+### I2C device not found
 
-You can configure multiple metrics to display. Each metric has:
+1) Ensure I2C is enabled: Settings → System → Hardware → All hardware → ⋮ → Enable I2C → Reboot host.
 
-| Option | Description | Default |
-|--------|-------------|---------|
-| `type` | Metric type (cpu, memory, disk, temperature, uptime) | - |
-| `position` | Display position (1-10) | - |
-| `show_bar` | Whether to show a bar graph | true |
-| `label` | Custom label for the metric | (metric type) |
-| `mount_point` | Mount point for disk metrics | / |
+2) After reboot, confirm `/dev/i2c-1` is listed under hardware in HA.
 
-### Custom Text
+3) Wiring: VCC→3.3V, GND→GND, SCL→GPIO3 (SCL), SDA→GPIO2 (SDA).
 
-| Option | Description | Default |
-|--------|-------------|---------|
-| `enabled` | Whether to show custom text | false |
-| `position` | Display position | 4 |
-| `text` | Text to display | Home Assistant |
+4) Set `i2c_port: "1"` if auto-detection fails.
 
-### Network Options
+If I2C is missing at startup, the add-on now falls back to debug mode and prints metrics in logs until I2C becomes available.
 
-| Option | Description | Default |
-|--------|-------------|---------|
-| `show_ip` | Whether to show IP address | false |
-| `position` | Display position | 5 |
-| `interface` | Network interface to use | eth0 |
-| `label` | Label for IP address | IP |
+### Debug mode
 
-## Troubleshooting
+Set `debug_mode: true` to run without the OLED. This is automatic if initialization fails.
 
-### I2C Device Not Found
+## Example configurations
 
-If you get an error like `DeviceNotFoundError: I2C device not found: /dev/i2c-1`, try these steps:
-
-1. **Enable I2C in Home Assistant:**
-   - Go to Settings → System → Hardware
-   - Enable I2C interface
-
-2. **Check available I2C devices:**
-   - Set `debug_mode: true` in the configuration
-   - Check the add-on logs to see what devices are available
-
-3. **Manual I2C port configuration:**
-   - Set `i2c_port` to a specific value (0, 1, etc.) instead of "auto"
-   - Common values: 0 for Raspberry Pi Zero, 1 for Raspberry Pi 3/4
-
-4. **Verify hardware connections:**
-   - Ensure proper wiring (VCC, GND, SCL, SDA)
-   - Check that the display is powered correctly
-
-### Debug Mode
-
-Enable debug mode to test the add-on without an OLED display:
-
+### Minimal (defaults)
 ```yaml
-system:
-  debug_mode: true
+display_type: "sh1106"
+i2c_address: "0x3C"
+i2c_port: "auto"
 ```
 
-This will output all metrics to the console/logs instead of trying to use the OLED display.
-
-## Example Configurations
-
-### Basic System Monitor
+### Customized layout
 ```yaml
-display:
-  type: "sh1106"
-  i2c_address: "0x3C"
-  i2c_port: "auto"
-metrics:
-  - type: "cpu"
-    position: 1
-  - type: "memory"
-    position: 2
-  - type: "disk"
-    position: 3
-```
-
-### Debug Mode for Testing
-```yaml
-system:
-  debug_mode: true
-  update_interval: 5
-display:
-  i2c_port: "auto"
-metrics:
-  - type: "cpu"
-    position: 1
-  - type: "memory"
-    position: 2
-  - type: "temperature"
-    position: 3
+title: "Home Assistant"
+show_title: true
+show_temperature: true
+show_cpu: true
+show_memory: true
+show_disk: true
+disk_mount_point: "/"
+show_temperature_metric: false
+show_uptime: true
+custom_text_enabled: true
+custom_text: "Welcome"
+custom_text_position: 4
+show_ip: true
+network_interface: "eth0"
+network_label: "IP"
 ```
 
 ## Changelog

--- a/oled-display/README.md
+++ b/oled-display/README.md
@@ -65,6 +65,29 @@ Key settings:
 
 If I2C is missing at startup, the add-on now falls back to debug mode and prints metrics in logs until I2C becomes available.
 
+### Enable I2C via Home Assistant Operating System terminal
+
+Alternatively, by attaching a keyboard and screen to your device, you can access the physical terminal to the Home Assistant Operating System.
+
+You can enable I2C via this terminal (from Home Assistant docs):
+
+1. Login as root.
+2. Type `login` and press enter to access the shell.
+3. Type the following to enable I2C, you may need to replace `sda1` with `sdb1` or `mmcblk0p1` depending on your platform:
+
+```
+mkdir /tmp/mnt
+mount /dev/sda1 /tmp/mnt
+mkdir -p /tmp/mnt/modules
+echo -ne i2c-dev>/tmp/mnt/modules/rpi-i2c.conf
+echo dtparam=i2c_vc=on >> /tmp/mnt/config.txt
+echo dtparam=i2c_arm=on >> /tmp/mnt/config.txt
+sync
+reboot
+```
+
+Source: Home Assistant OS Common Tasks (`https://www.home-assistant.io/common-tasks/os/`).
+
 ### Debug mode
 
 Set `debug_mode: true` to run without the OLED. This is automatic if initialization fails.

--- a/oled-display/build.yaml
+++ b/oled-display/build.yaml
@@ -1,2 +1,2 @@
 build_from:
-  aarch64: "ghcr.io/home-assistant/aarch64-base:3.18"
+  aarch64: "ghcr.io/home-assistant/aarch64-addon-base:3.18"

--- a/oled-display/build.yaml
+++ b/oled-display/build.yaml
@@ -1,6 +1,2 @@
 build_from:
   aarch64: "ghcr.io/home-assistant/aarch64-base:3.18"
-  amd64: "ghcr.io/home-assistant/amd64-base:3.18"
-  armhf: "ghcr.io/home-assistant/armhf-base:3.18"
-  armv7: "ghcr.io/home-assistant/armv7-base:3.18"
-  i386: "ghcr.io/home-assistant/i386-base:3.18"

--- a/oled-display/config.yaml
+++ b/oled-display/config.yaml
@@ -1,16 +1,14 @@
 name: "OLED System Monitor"
 description: "OLED stats display for Raspberry Pi 5 on Home Assistant OS"
-version: "1.1.0"
+version: "1.2.0"
 slug: "oled_display"
 init: false
 arch:
   - aarch64
-  - armv7
 startup: application
 boot: auto
 devices:
   - /dev/i2c-1
-  - /dev/i2c-0
 gpio: true
 privileged:
   - SYS_RAWIO

--- a/oled-display/config.yaml
+++ b/oled-display/config.yaml
@@ -1,11 +1,10 @@
 name: "OLED System Monitor"
-description: "Customizable system stats display for OLED screens"
-version: "1.0.2"
+description: "OLED stats display for Raspberry Pi 5 on Home Assistant OS"
+version: "1.1.0"
 slug: "oled_display"
 init: false
 arch:
   - aarch64
-  - armhf
   - armv7
 startup: application
 boot: auto
@@ -16,70 +15,68 @@ gpio: true
 privileged:
   - SYS_RAWIO
 options:
-  display:
-    type: "sh1106"
-    i2c_address: "0x3C"
-    i2c_port: "auto"
-    width: 128
-    height: 64
-    rotate: 0
-    contrast: 255
-  system:
-    update_interval: 1
-    title: "home assistant"
-    show_title: true
-    show_temperature: true
-    debug_mode: false
-  metrics:
-    - type: "cpu"
-      position: 1
-      show_bar: true
-      label: "CPU"
-    - type: "memory"
-      position: 2
-      show_bar: true
-      label: "RAM"
-    - type: "disk"
-      position: 3
-      show_bar: true
-      label: "DISK"
-      mount_point: "/"
-  custom_text:
-    enabled: false
-    position: 4
-    text: "Home Assistant"
-  network:
-    show_ip: false
-    position: 5
-    interface: "eth0"
-    label: "IP"
+  # Display
+  display_type: "sh1106"
+  i2c_address: "0x3C"  # Most 128x64 modules use 0x3C
+  i2c_port: "auto"     # Usually 1 on Raspberry Pi 5
+  width: 128
+  height: 64
+  rotate: 0
+  contrast: 255
+
+  # Behavior
+  update_interval: 1
+  title: "Home Assistant"
+  show_title: true
+  show_temperature: true
+  debug_mode: false
+
+  # Metric toggles (simplified)
+  show_cpu: true
+  show_memory: true
+  show_disk: true
+  disk_mount_point: "/"
+  show_temperature_metric: false
+  show_uptime: false
+
+  # Custom text
+  custom_text_enabled: false
+  custom_text_position: 4
+  custom_text: "Home Assistant"
+
+  # Network label
+  show_ip: false
+  network_position: 5
+  network_interface: "eth0"
+  network_label: "IP"
+
 schema:
-  display:
-    type: list(ssd1306|sh1106)
-    i2c_address: str
-    i2c_port: str
-    width: int
-    height: int
-    rotate: list(0|1|2|3)
-    contrast: int(0,255)
-  system:
-    update_interval: int(1,60)
-    title: str
-    show_title: bool
-    show_temperature: bool
-    debug_mode: bool
-  metrics:
-    - type: list(cpu|memory|disk|temperature|uptime)
-      position: int(1,10)
-      show_bar: bool
-      label: str
-      mount_point: str?
-  custom_text:
-    enabled: bool
-    position: int(1,10)
-    text: str
-  network:
-    show_ip: bool
-    position: int(1,10)
-    interface: str
-    label: str
+  display_type: list(ssd1306|sh1106)
+  i2c_address: str
+  i2c_port: str
+  width: int
+  height: int
+  rotate: list(0|1|2|3)
+  contrast: int(0,255)
+
+  update_interval: int(1,60)
+  title: str
+  show_title: bool
+  show_temperature: bool
+  debug_mode: bool
+
+  show_cpu: bool
+  show_memory: bool
+  show_disk: bool
+  disk_mount_point: str
+  show_temperature_metric: bool
+  show_uptime: bool
+
+  custom_text_enabled: bool
+  custom_text_position: int(1,10)
+  custom_text: str
+
+  show_ip: bool
+  network_position: int(1,10)
+  network_interface: str
+  network_label: str

--- a/oled-display/rootfs/usr/bin/oled_monitor.py
+++ b/oled-display/rootfs/usr/bin/oled_monitor.py
@@ -181,8 +181,10 @@ try:
     else:
         device = initialize_display()
         if device is None:
-            print("CRITICAL: Could not initialize OLED display. Exiting.")
-            exit(1)
+            print("WARNING: OLED initialization failed or no I2C device. Falling back to debug mode.")
+            debug_mode = True
+            print("DEBUG MODE: Running without OLED display")
+            device = None
 
     while True:
         # Get temperature for title

--- a/oled-display/translations/en.yaml
+++ b/oled-display/translations/en.yaml
@@ -1,0 +1,83 @@
+name: OLED System Monitor
+description: OLED stats display for Raspberry Pi 5 on Home Assistant OS
+configuration:
+  options:
+    display_type:
+      name: Display type
+      description: Select your OLED controller (most 128x64 are SH1106 or SSD1306).
+    i2c_address:
+      name: I2C address
+      description: Hex address of the display (common is 0x3C).
+    i2c_port:
+      name: I2C bus
+      description: Bus number (use auto on RPi 5, usually 1).
+    width:
+      name: Width
+      description: Display width in pixels (e.g., 128).
+    height:
+      name: Height
+      description: Display height in pixels (e.g., 64).
+    rotate:
+      name: Rotation
+      description: Rotate content if your display is mounted differently (0,1,2,3).
+    contrast:
+      name: Contrast
+      description: Brightness level from 0 (dim) to 255 (bright).
+
+    update_interval:
+      name: Update interval
+      description: Seconds between screen updates.
+    title:
+      name: Title
+      description: Header text shown on the first line.
+    show_title:
+      name: Show title
+      description: Toggle the header line.
+    show_temperature:
+      name: Show CPU temperature next to title
+      description: Show CPU temperature alongside the header.
+    debug_mode:
+      name: Debug mode
+      description: Log metrics to console without using the OLED.
+
+    show_cpu:
+      name: Show CPU metric
+      description: Display CPU usage with a bar.
+    show_memory:
+      name: Show memory metric
+      description: Display memory usage with a bar.
+    show_disk:
+      name: Show disk metric
+      description: Display disk usage with a bar.
+    disk_mount_point:
+      name: Disk mount point
+      description: Mount path for the disk metric (e.g., /).
+    show_temperature_metric:
+      name: Show temperature metric
+      description: Display CPU temperature as a metric line.
+    show_uptime:
+      name: Show uptime metric
+      description: Display system uptime as a metric line.
+
+    custom_text_enabled:
+      name: Show custom text
+      description: Enable a custom text line.
+    custom_text:
+      name: Custom text
+      description: The text to show.
+    custom_text_position:
+      name: Custom text position
+      description: Line position for the custom text.
+
+    show_ip:
+      name: Show IP address
+      description: Display the IP address line.
+    network_interface:
+      name: Network interface
+      description: Interface to use when showing the IP (e.g., eth0).
+    network_label:
+      name: Network label
+      description: Label prefix for the IP line (e.g., IP).
+    network_position:
+      name: Network line position
+      description: Line position for the IP address.


### PR DESCRIPTION
Implement a fallback to debug mode when OLED initialization fails to prevent service exit when I2C is unavailable.

---
<a href="https://cursor.com/background-agent?bcId=bc-a99c6ec0-f807-418a-a20a-16c0bd7c3429">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a99c6ec0-f807-418a-a20a-16c0bd7c3429">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

